### PR TITLE
Shiny Items

### DIFF
--- a/gm4_shiny_items_1_15/data/gm4_shiny_items/functions/blacklist_items.mcfunction
+++ b/gm4_shiny_items_1_15/data/gm4_shiny_items/functions/blacklist_items.mcfunction
@@ -1,0 +1,81 @@
+#run from main
+
+#@s = At all players
+
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist] unless entity @s[nbt={Item:{Count:1b}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{tag:{Enchantments:[{lvl:1s}]}}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{tag:{Enchantments:[{lvl:2s}]}}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{tag:{Enchantments:[{lvl:3s}]}}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{tag:{Enchantments:[{lvl:4s}]}}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{tag:{Enchantments:[{lvl:5s}]}}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist] if block ~ ~-.6 ~ hopper run tag @s add gm4_shiny_blacklist
+
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:enchanted_book"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:potion"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:splash_potion"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:lingering_potion"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:experience_bottle"}}] run tag @s add gm4_shiny_blacklist
+
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:wooden_sword"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:wooden_axe"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:wooden_pickaxe"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:wooden_shovel"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:wooden_hoe"}}] run tag @s add gm4_shiny_blacklist
+
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:stone_sword"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:stone_axe"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:stone_pickaxe"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:stone_shovel"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:stone_hoe"}}] run tag @s add gm4_shiny_blacklist
+
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:iron_sword"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:iron_axe"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:iron_pickaxe"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:iron_shovel"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:iron_hoe"}}] run tag @s add gm4_shiny_blacklist
+
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:golden_sword"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:golden_axe"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:golden_pickaxe"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:golden_shovel"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:golden_hoe"}}] run tag @s add gm4_shiny_blacklist
+
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:diamond_sword"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:diamond_axe"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:diamond_pickaxe"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:diamond_shovel"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:diamond_hoe"}}] run tag @s add gm4_shiny_blacklist
+
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:flint_and_steel"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:shears"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:fishing_rod"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:bow"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:crossbow"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:trident"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:shield"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:carrot_on_a_stick"}}] run tag @s add gm4_shiny_blacklist
+
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:leather_helmet"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:leather_chestplate"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:leather_leggings"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:leather_boots"}}] run tag @s add gm4_shiny_blacklist
+
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:chainmail_helmet"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:chainmail_chestplate"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:chainmail_leggings"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:chainmail_boots"}}] run tag @s add gm4_shiny_blacklist
+
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:iron_helmet"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:iron_chestplate"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:iron_leggings"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:iron_boots"}}] run tag @s add gm4_shiny_blacklist
+
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:diamond_helmet"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:diamond_chestplate"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:diamond_leggings"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:diamond_boots"}}] run tag @s add gm4_shiny_blacklist
+
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:golden_helmet"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:golden_chestplate"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:golden_leggings"}}] run tag @s add gm4_shiny_blacklist
+execute as @e[type=item,distance=..30,tag=!gm4_shiny_blacklist,nbt={Item:{id:"minecraft:golden_boots"}}] run tag @s add gm4_shiny_blacklist

--- a/gm4_shiny_items_1_15/data/gm4_shiny_items/functions/init.mcfunction
+++ b/gm4_shiny_items_1_15/data/gm4_shiny_items/functions/init.mcfunction
@@ -1,0 +1,12 @@
+scoreboard objectives add gm4_absorbed_xp dummy
+scoreboard objectives add gm4_xporb_xp dummy
+
+execute unless score shiny_items gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"shiny items"}
+scoreboard players set shiny_items gm4_modules 1
+
+schedule function gm4_shiny_items:main 10t
+schedule function gm4_shiny_items:tick 10t
+
+#$moduleUpdateList
+
+

--- a/gm4_shiny_items_1_15/data/gm4_shiny_items/functions/load.mcfunction
+++ b/gm4_shiny_items_1_15/data/gm4_shiny_items/functions/load.mcfunction
@@ -1,0 +1,5 @@
+execute if score gm4 load matches 1 run scoreboard players set gm4_shiny_items load 1
+execute unless score gm4 load matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"shiny items",require:"Gamemode 4"}
+
+execute if score gm4_shiny_items load matches 1 run function gm4_shiny_items:init
+execute unless score gm4_shiny_items load matches 1 run schedule clear gm4_shiny_items:main

--- a/gm4_shiny_items_1_15/data/gm4_shiny_items/functions/main.mcfunction
+++ b/gm4_shiny_items_1_15/data/gm4_shiny_items/functions/main.mcfunction
@@ -1,0 +1,63 @@
+
+schedule function gm4_shiny_items:main 16t
+
+########## TAG: gm4_shiny_blacklist
+
+execute as @a at @s run function gm4_shiny_items:blacklist_items
+
+########## TAG: gm4_can_become_shiny
+
+execute as @e[type=minecraft:item,tag=!gm4_shiny_blacklist] at @s if entity @a[distance=3..10] if entity @e[type=minecraft:experience_orb,distance=..2,tag=!gm4_shiny_blacklist] unless entity @e[distance=..2,nbt={Item:{tag:{HideFlags:44}}}] run tag @s add gm4_can_become_shiny
+execute as @e[tag=gm4_can_become_shiny] at @s run data modify entity @s Item.tag.HideFlags set value 44
+execute as @e[tag=gm4_can_become_shiny] at @s unless entity @e[type=minecraft:experience_orb,distance=..2] run data remove entity @s Item.tag.HideFlags
+execute as @e[tag=gm4_can_become_shiny] at @s unless entity @e[type=minecraft:experience_orb,distance=..2] run tag @s remove gm4_can_become_shiny
+
+########## TAG: gm4_can_be_absorbed
+
+execute as @e[type=minecraft:experience_orb] at @s if entity @e[tag=gm4_can_become_shiny,distance=..2] run tag @s add gm4_can_be_absorbed
+execute as @e[tag=gm4_can_be_absorbed] at @s unless entity @e[tag=gm4_can_become_shiny,distance=..2] run tag @s remove gm4_can_be_absorbed
+
+########## COPY VALUE TO SCORE, TRANSFER XP TO ITEM
+
+execute as @e[tag=gm4_can_be_absorbed] at @s facing entity @e[tag=gm4_can_become_shiny,sort=nearest,limit=1,distance=0.2..2] feet run tp ^ ^ ^.03
+
+execute as @e[tag=gm4_can_be_absorbed] at @s store result score @s gm4_xporb_xp run data get entity @s Value 1
+
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=1..}] at @s run particle dust 1.000 0.031 0.000 1 ~ ~.2 ~ .05 .05 .05 .1 1 
+execute as @e[type=item,scores={gm4_absorbed_xp=1..}] at @s run particle minecraft:enchant ~ ~.4 ~ .1 .1 .1 .01 1
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=1..}] at @s at @e[tag=gm4_can_become_shiny,limit=1,sort=nearest] run particle minecraft:enchant ~ ~.4 ~ .1 .1 .1 .01 3
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=1..}] at @s at @e[tag=gm4_can_become_shiny,limit=1,sort=nearest,scores={gm4_absorbed_xp=1..25},distance=..5] run playsound minecraft:entity.puffer_fish.blow_up ambient @a[distance=..15] ~ ~ ~ .2 .1
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=1..}] at @s at @e[tag=gm4_can_become_shiny,limit=1,sort=nearest,scores={gm4_absorbed_xp=26..50},distance=..5] run playsound minecraft:entity.puffer_fish.blow_up ambient @a[distance=..15] ~ ~ ~ .2 .4
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=1..}] at @s at @e[tag=gm4_can_become_shiny,limit=1,sort=nearest,scores={gm4_absorbed_xp=51..75},distance=..5] run playsound minecraft:entity.puffer_fish.blow_up ambient @a[distance=..15] ~ ~ ~ .2 .8
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=1..}] at @s at @e[tag=gm4_can_become_shiny,limit=1,sort=nearest,scores={gm4_absorbed_xp=76..100},distance=..5] run playsound minecraft:entity.puffer_fish.blow_up ambient @a[distance=..15] ~ ~ ~ .2 1.2
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=1..}] at @s at @e[tag=gm4_can_become_shiny,limit=1,sort=nearest,scores={gm4_absorbed_xp=101..125},distance=..5] run playsound minecraft:entity.puffer_fish.blow_up ambient @a[distance=..15] ~ ~ ~ .2 1.6
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=1..}] at @s at @e[tag=gm4_can_become_shiny,limit=1,sort=nearest,scores={gm4_absorbed_xp=126..150},distance=..5] run playsound minecraft:entity.puffer_fish.blow_up ambient @a[distance=..15] ~ ~ ~ .2 2
+
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=1..}] at @s run scoreboard players add @e[tag=gm4_can_become_shiny,limit=1,sort=nearest] gm4_absorbed_xp 1
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=2..}] at @s run scoreboard players add @e[tag=gm4_can_become_shiny,limit=1,sort=nearest] gm4_absorbed_xp 1
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=3..}] at @s run scoreboard players add @e[tag=gm4_can_become_shiny,limit=1,sort=nearest] gm4_absorbed_xp 1
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=4..}] at @s run scoreboard players add @e[tag=gm4_can_become_shiny,limit=1,sort=nearest] gm4_absorbed_xp 1
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=5..}] at @s run scoreboard players add @e[tag=gm4_can_become_shiny,limit=1,sort=nearest] gm4_absorbed_xp 1
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=6..}] at @s run scoreboard players add @e[tag=gm4_can_become_shiny,limit=1,sort=nearest] gm4_absorbed_xp 1
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=7..}] at @s run scoreboard players add @e[tag=gm4_can_become_shiny,limit=1,sort=nearest] gm4_absorbed_xp 1
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=8..}] at @s run scoreboard players add @e[tag=gm4_can_become_shiny,limit=1,sort=nearest] gm4_absorbed_xp 1
+
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=9..}] at @s run scoreboard players add @e[tag=gm4_can_become_shiny,limit=1,sort=nearest] gm4_absorbed_xp 1
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=10..}] at @s run scoreboard players add @e[tag=gm4_can_become_shiny,limit=1,sort=nearest] gm4_absorbed_xp 1
+
+execute as @e[tag=gm4_can_be_absorbed,scores={gm4_xporb_xp=1..}] at @s run scoreboard players remove @s gm4_xporb_xp 10
+execute as @e[tag=gm4_can_be_absorbed] at @s store result entity @s Value short 1 run scoreboard players get @s gm4_xporb_xp
+
+########## MAKE ITEM SHINY
+
+execute as @e[scores={gm4_xporb_xp=..0}] at @s run particle dust 1.000 0.031 0.000 1 ~ ~.3 ~ .1 .1 .1 .1 5 
+execute as @e[scores={gm4_xporb_xp=..0}] at @s run kill @s
+
+execute as @e[scores={gm4_absorbed_xp=150..}] at @s run data remove entity @s Item.tag.HideFlags
+execute as @e[scores={gm4_absorbed_xp=150..}] at @s run data modify entity @s Item.tag.Enchantments set value [{id:"minecraft:lure",lvl:1s}]
+execute as @e[scores={gm4_absorbed_xp=150..}] at @s run data modify entity @s Item.tag.HideFlags set value 1
+execute as @e[scores={gm4_absorbed_xp=150..}] at @s run tag @s add gm4_shiny_blacklist
+execute as @e[scores={gm4_absorbed_xp=150..}] at @s run tag @s remove gm4_can_become_shiny
+execute as @e[scores={gm4_absorbed_xp=150..}] at @s run playsound minecraft:entity.experience_orb.pickup ambient @a[distance=..15] ~ ~ ~ .1 .5
+scoreboard players reset @e[scores={gm4_absorbed_xp=150..}] gm4_absorbed_xp
+

--- a/gm4_shiny_items_1_15/data/gm4_shiny_items/functions/tick.mcfunction
+++ b/gm4_shiny_items_1_15/data/gm4_shiny_items/functions/tick.mcfunction
@@ -1,0 +1,9 @@
+
+schedule function gm4_shiny_items:tick 1t
+
+execute as @e[tag=gm4_can_become_shiny] at @s if entity @a[distance=..2] run function gm4_shiny_items:undo_item_progress
+execute as @e[scores={gm4_absorbed_xp=1..}] at @s if entity @a[distance=..2] run function gm4_shiny_items:undo_item_progress
+
+execute as @e[tag=gm4_can_become_shiny] at @s if block ~ ~-.6 ~ hopper run function gm4_shiny_items:undo_item_progress
+execute as @e[scores={gm4_absorbed_xp=1..}] at @s if block ~ ~-6 ~ hopper run function gm4_shiny_items:undo_item_progress
+

--- a/gm4_shiny_items_1_15/data/gm4_shiny_items/functions/undo_item_progress.mcfunction
+++ b/gm4_shiny_items_1_15/data/gm4_shiny_items/functions/undo_item_progress.mcfunction
@@ -1,0 +1,16 @@
+#run from tick
+
+#@s = An item that looses the tag "gm4_can_become_shiny" because a player tries to pick it up
+
+playsound minecraft:entity.puffer_fish.blow_out ambient @a[distance=..15] ~ ~ ~ .3 .8
+
+data remove entity @s Item.tag.HideFlags
+
+summon minecraft:experience_orb ~ ~ ~ {Value:0,Tags:["gm4_refund_xp","gm4_shiny_blacklist"]}
+execute as @s at @s store result entity @e[type=minecraft:experience_orb,sort=nearest,limit=1,tag=gm4_refund_xp] Value short 1 run scoreboard players get @s gm4_absorbed_xp
+execute as @s at @s as @e[type=minecraft:experience_orb,sort=nearest,limit=1,tag=gm4_refund_xp] run tag @s remove gm4_refund_xp
+
+scoreboard players reset @s gm4_absorbed_xp 
+
+tag @s add gm4_shiny_blacklist
+tag @s remove gm4_can_become_shiny

--- a/gm4_shiny_items_1_15/data/load/tags/functions/gm4_shiny_items.json
+++ b/gm4_shiny_items_1_15/data/load/tags/functions/gm4_shiny_items.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "gm4_shiny_items:load"
+    ]
+}

--- a/gm4_shiny_items_1_15/data/load/tags/functions/load.json
+++ b/gm4_shiny_items_1_15/data/load/tags/functions/load.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "#load:gm4_shiny_items"
+    ]
+}

--- a/gm4_shiny_items_1_15/pack.mcmeta
+++ b/gm4_shiny_items_1_15/pack.mcmeta
@@ -1,0 +1,40 @@
+{
+    "pack": {
+        "pack_format": 5,
+        "description": "A Gamemode 4 Module"
+    },
+    "module_name": "shiny items",
+    "module_id": "shiny_items",
+  "creation_meta":"Created using the Gamemode 4 Module Template Generator (gm4.co/modules/generator)",
+    "site_description": "Someone forgot to type a description!",
+    "site_categories": [],
+    "video_link": "YOUTUBE_VIDEO_URL",
+    "wiki_link": "WIKI_URL",
+    "required_modules": [
+        "module_id of required module",
+        "or leave array empty"
+    ],
+    "recommended_modules": [
+        "module_id of recommended module",
+        "or leave array empty"
+    ],
+    "credits": {
+        "comment": "All credit arrays are optional and more can be created as needed. They will be displayed on the site page under their headings. -- REMOVE THIS COMMENT",
+        "Creator": [
+            [
+                "USERNAME",
+                "OPTIONAL_LINK"
+            ]
+        ],
+        "Updated By": [
+            [
+                "USERNAME",
+                "OPTIONAL_LINK"
+            ],
+            [
+                "USERNAME",
+                "OPTIONAL_LINK"
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
This module allows the player to apply the enchantment glow to most items in the game (look at function "blacklist_items" for a list of blacklisted items). This can be used by players to draw attention to items they find special and want to show off.

To get a "shiny" item the player must simply throw an item near xp orbs. Slowly the item will consume xp from the nearby orbs and once it has collected 150 points worth of xp, it will become "shiny".